### PR TITLE
DB Cronjob for the Backup

### DIFF
--- a/deploy/templates/db.cronjob.yaml
+++ b/deploy/templates/db.cronjob.yaml
@@ -1,4 +1,4 @@
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: {{ .Values.db.name }}-cronjob

--- a/deploy/templates/db.cronjob.yaml
+++ b/deploy/templates/db.cronjob.yaml
@@ -33,6 +33,7 @@ spec:
               volumeMounts:
               - name: pg-persistent-storage
                 mountPath: /backups
+          restartPolicy: OnFailure
           volumes:
           - name: pg-persistent-storage
             persistentVolumeClaim:

--- a/deploy/templates/db.cronjob.yaml
+++ b/deploy/templates/db.cronjob.yaml
@@ -1,0 +1,39 @@
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: {{ .Values.db.name }}-cronjob
+  namespace: {{ .Values.namespace }}
+spec:
+  schedule: "0 1 1 * *"  # Run every month at 1am
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+            - name: pg-backup
+              image: postgres:15
+              command: ["/bin/bash", "-c"]
+              args: ["pg_dump -h {{ .Values.db.name }}-svc -U $PGUSER $PGDB -w -F t -f /backups/db-$(date +%Y-%m-%d_%H-%M-%S).tar"]
+              env:
+              - name: PGUSER
+                valueFrom:
+                  secretKeyRef:
+                    name: {{ .Values.db.name }}-creds
+                    key: user
+              - name: PGDB
+                valueFrom:
+                  secretKeyRef:
+                    name: {{ .Values.db.name }}-creds
+                    key: db
+              - name: PGPASSWORD
+                valueFrom:
+                  secretKeyRef:
+                    name: {{ .Values.db.name }}-creds
+                    key: password
+              volumeMounts:
+              - name: pg-persistent-storage
+                mountPath: /backups
+          volumes:
+          - name: pg-persistent-storage
+            persistentVolumeClaim:
+              claimName: {{ .Values.db.name }}-backup-pvc

--- a/deploy/templates/db.pvc.yaml
+++ b/deploy/templates/db.pvc.yaml
@@ -10,3 +10,16 @@ spec:
   resources:
     requests:
       storage: 10Gi
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ .Values.db.name }}-backup-pvc
+  namespace: {{ .Values.namespace }}
+spec:
+  storageClassName: "cinder-csi-ssd"
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 20Gi


### PR DESCRIPTION
Close #32 

The PR includes a cronjob putting a backup every month into a PVC. In the future it can be improved with external storage and more frequent backups.

I didn't yet apply anything but tried whether it would be applied successfully with:
```bash
helm template -f values-prod.yaml --set db.password=BLA . | k apply --dry-run=client -f - 
```

The commands in the cronjob was only tested locally with pg v14